### PR TITLE
Add: 로그인 핸들러 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "prettier": "^3.3.3"
   },
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "dotenv": "^16.4.5",
+    "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
     "long": "^5.2.3",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,4 +1,11 @@
-import { DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER } from '../constants/env.js';
+import {
+  DB_HOST,
+  DB_NAME,
+  DB_PASSWORD,
+  DB_PORT,
+  DB_USER,
+  JWT_SECRET_KEY,
+} from '../constants/env.js';
 
 export const config = {
   database: {
@@ -13,5 +20,9 @@ export const config = {
     UNKNOWN_ERROR: 1,
     INVALID_REQUEST: 2,
     AUTHENTICATION_FAILED: 3,
+  },
+  jwt: {
+    secret: JWT_SECRET_KEY,
+    expiresIn: '24h',
   },
 };

--- a/src/constants/env.js
+++ b/src/constants/env.js
@@ -8,6 +8,8 @@ export const CLIENT_VERSION = process.env.CLIENT_VERSION || '1.0.0';
 
 export const DB_NAME = process.env.DB_NAME || 'USERS_DB';
 export const DB_USER = process.env.DB_USER || 'root';
-export const DB_PASSWORD = process.env.DB_PASSWORD || '';
+export const DB_PASSWORD = process.env.DB_PASSWORD || 'aaaa4321';
 export const DB_HOST = process.env.DB_HOST || '127.0.0.1';
 export const DB_PORT = process.env.DB_PORT || '3306';
+
+export const JWT_SECRET_KEY = process.env.JWT_SECRET_KEY || 'secret-key';

--- a/src/db/users/user.queries.js
+++ b/src/db/users/user.queries.js
@@ -1,6 +1,6 @@
 export const SQL_QUERIES = {
   FIND_USER_BY_ID: 'SELECT * FROM users WHERE id = ?',
   CREATE_USER: 'INSERT INTO users (id, password, email) VALUES (?, ?, ?)',
-  UPDATE_USER_LOGIN: 'UDPATE users SET last_login = CURRENT_TIMESTAMP WHERE id = ?',
+  UPDATE_USER_LOGIN: 'UPDATE users SET last_login = CURRENT_TIMESTAMP WHERE id = ?',
   FIND_PASSWORD_BY_ID: 'SELECT  FROM users WHERE id = ?',
 };

--- a/src/handlers/user/login.handler.js
+++ b/src/handlers/user/login.handler.js
@@ -1,17 +1,76 @@
 import { HANDLER_IDS, RESPONSE_SUCCESS_CODE } from '../../constants/handlerId.js';
 import { findUserById, updateUserLogin } from '../../db/users/user.db.js';
 import { addUser } from '../../sessions/user.session.js';
+import joi from 'joi';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { config } from '../../config/config.js';
+import { createS2CLoginResponse } from '../../utils/response/createS2CLoginResponse.js';
+
+const schema = joi.object({
+  id: joi.string().required().messages({
+    'any.required': 'id를 입력해주세요.',
+  }),
+  password: joi.string().required().messages({
+    'any.required': 'password를 입력해주세요.',
+  }),
+});
 
 export const loginHandler = async ({ packetType, data, socket }) => {
   try {
     const { id, password } = data;
-    console.log('login');
+    console.log('login id: ', id);
 
+    let loginResponse;
+    // db에 유저 검색
     const user = await findUserById(id);
+
     if (!user) {
+      // 유저가 없으면 오류
+      loginResponse = createS2CLoginResponse(
+        id,
+        false,
+        '존재하지 않는 사용자입니다.',
+        '',
+        config.globalFailCode.AUTHENTICATION_FAILED,
+      );
     } else {
+      // 유저가 존재하면 password 비교
+      const isPasswordValid = await bcrypt.compare(password, user.password);
+
+      // 비밀번호가 틀렸다면
+      if (!isPasswordValid) {
+        loginResponse = createS2CLoginResponse(
+          id,
+          false,
+          '비밀번호가 일치하지 않습니다.',
+          '',
+          config.globalFailCode.AUTHENTICATION_FAILED,
+        );
+      } else {
+        // 로그인 성공 시
+        const token = jwt.sign({ id: user.id }, config.jwt.secret, {
+          expiresIn: config.jwt.expiresIn,
+        });
+
+        // 유저 마지막 로그인 업데이트
+        await updateUserLogin(id);
+
+        // 세션에 유저 추가
+        addUser(id, socket);
+
+        loginResponse = createS2CLoginResponse(
+          id,
+          true,
+          '로그인 성공',
+          token,
+          config.globalFailCode.NONE,
+        );
+      }
     }
 
-    // const loginResponse = createS2CRegisterResponse();
-  } catch (e) {}
+    socket.write(loginResponse);
+  } catch (e) {
+    console.error('Login handler error: ', e);
+  }
 };

--- a/src/handlers/user/register.handler.js
+++ b/src/handlers/user/register.handler.js
@@ -1,5 +1,4 @@
 import { createS2CRegisterResponse } from '../../utils/response/createS2CRegisterResponse.js';
-import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
 import joi from 'joi';
 import { createUser, findUserById } from '../../db/users/user.db.js';

--- a/src/sessions/user.session.js
+++ b/src/sessions/user.session.js
@@ -1,8 +1,8 @@
 import User from '../classes/models/user.class.js';
 import { userSessions } from './sessions.js';
 
-export const addUser = (socket, id, playerId, latency) => {
-  const user = new User(socket, id, playerId, latency);
+export const addUser = (socket, id) => {
+  const user = new User(socket, id);
   userSessions.push(user);
   return user;
 };

--- a/src/utils/response/createS2CLoginResponse.js
+++ b/src/utils/response/createS2CLoginResponse.js
@@ -10,29 +10,28 @@ import { createHeader } from './createHeader.js';
  * @param {GlobalFailCode} failCode
  * @returns
  */
-export const createS2CRegisterResponse = (userId, success, message, failCode) => {
+export const createS2CLoginResponse = (userId, success, message, token, failCode) => {
   try {
     const protoMessages = getProtoMessages();
     const GamePacket = protoMessages['protoPacket']['GamePacket'];
-    const Response = protoMessages.response.S2CRegisterResponse;
-    const registerResponse = Response.create({
+    const Response = protoMessages.response.S2CLoginResponse;
+    const loginResponse = Response.create({
       success,
       message,
+      token,
       failCode,
     });
 
-    console.log('success: ', success);
-    console.log('message: ', message);
-    console.log('failCode: ', failCode);
+    console.log('loginResponse: ', loginResponse);
 
     const gamePacket = GamePacket.create({
-      registerResponse,
+      loginResponse,
     });
 
     const sequence = getNextSequence(userId);
     const buffer = GamePacket.encode(gamePacket).finish();
 
-    const headerPacket = createHeader(PacketType.REGISTER_RESPONSE, sequence, buffer.length);
+    const headerPacket = createHeader(PacketType.LOGIN_RESPONSE, sequence, buffer.length);
 
     return Buffer.concat([headerPacket, buffer]);
   } catch (e) {


### PR DESCRIPTION
- 클라이언트의 로그인 요청을 처리
- 로그인 실패 시 적절한 에러 코드를 포함해 반환
- 로그인 성공 시 db의 lastlogin을 업데이트 하고 jwt token을 반환
- 유저를 유저 세션에 추가