### PR TITLE
시퀀스 체크 로직 구현

### DIFF
--- a/src/classes/models/client.class.js
+++ b/src/classes/models/client.class.js
@@ -1,0 +1,23 @@
+let clientCounter = 1; // 고유한 몬스터 ID 관리
+
+class Client {
+  constructor(socket) {
+    this.id = this.getClientId();
+    this.socket = socket;
+    this.sequence = 0;
+  }
+
+  getSequence() {
+    return this.sequence;
+  }
+
+  updateSequence() {
+    this.sequence++;
+  }
+
+  getClientId() {
+    return clientCounter++;
+  }
+}
+
+export default Client;

--- a/src/classes/models/monster.class.js
+++ b/src/classes/models/monster.class.js
@@ -18,18 +18,3 @@ class Monster {
 }
 
 export default Monster;
-
-// class Monster {
-//   constructor(monsterId, level) {
-//     this.id = monsterId;
-//     this.monsterNumber = this.getMonsterNumber(); // 이게 아마 몬스터 타입? (1~5 : 검/파/초/빨/노)
-//     this.level = level || 1; // 일단 없으면 1로 설정
-//   }
-
-//   getMonsterNumber() {
-//     const munsterNum = Math.floor(Math.random() * 5) + 1; // 몬스터 5마리네요
-//     return munsterNum;
-//   }
-// }
-
-// export default Monster;

--- a/src/classes/models/monster.class.js
+++ b/src/classes/models/monster.class.js
@@ -1,4 +1,4 @@
-let monsterCounter = 1; // 고유한 몬스터 ID 관리
+let monsterCounter = 0; // 고유한 몬스터 ID 관리
 
 class Monster {
   constructor(level) {

--- a/src/classes/models/tower.class.js
+++ b/src/classes/models/tower.class.js
@@ -13,13 +13,3 @@ class Tower {
 }
 
 export default Tower;
-
-// class Tower {
-//   constructor(towerId, x, y) {
-//     this.id = towerId;
-//     this.x = x;
-//     this.y = y;
-//   }
-// }
-
-// export default Tower;

--- a/src/classes/models/tower.class.js
+++ b/src/classes/models/tower.class.js
@@ -1,4 +1,4 @@
-let towerCounter = 2;
+let towerCounter = 0;
 
 class Tower {
   constructor(x, y) {

--- a/src/classes/models/user.class.js
+++ b/src/classes/models/user.class.js
@@ -162,7 +162,7 @@ class User {
     };
 
     const protoType = PacketType.STATE_SYNC_NOTIFICATION;
-    const packet = makeNotification(protoType, stateData);
+    const packet = makeNotification(protoType, stateData, this.socket);
     this.socket.write(packet);
   }
   getTower(towerId) {

--- a/src/classes/models/user.class.js
+++ b/src/classes/models/user.class.js
@@ -57,8 +57,9 @@ class User {
     return ++this.sequence;
   }
 
-  creatTower(x, y) {
-    const tower = new Tower(this.towerIdCounter++, x, y);
+  createTower(x, y) {
+    const tower = new Tower(x, y);
+    this.towers.push(tower);
     return tower;
   }
 
@@ -114,8 +115,9 @@ class User {
   }
 
   // 몬스터 정보 id 부여 후 저장
-  creatMonster(level = null) {
-    const monster = new Monster(this.monsterIdCounter++, level);
+  createMonster(level = null) {
+    const monster = new Monster(level);
+    this.monsters.push(monster);
     return monster;
   }
 

--- a/src/events/onConnection.js
+++ b/src/events/onConnection.js
@@ -1,3 +1,4 @@
+import { addClient } from '../sessions/client.session.js';
 import { onData } from './onData.js';
 import { onEnd } from './onEnd.js';
 import { onError } from './onError.js';
@@ -6,6 +7,7 @@ export const onConnection = (socket) => {
   console.log(`Client connected from: ${socket.remoteAddress}:${socket.remotePort}`);
 
   socket.buffer = Buffer.alloc(0);
+  addClient(socket);
 
   socket.on('data', onData(socket));
   socket.on('end', onEnd(socket));

--- a/src/events/onEnd.js
+++ b/src/events/onEnd.js
@@ -1,4 +1,5 @@
 import { createGameOverNotification, gameEnd } from '../handlers/game/monster.baseattack.js';
+import { removeClient } from '../sessions/client.session.js';
 import { getUserBySocket, removeUser } from '../sessions/user.session.js';
 
 export const onEnd = (socket) => () => {
@@ -18,6 +19,7 @@ export const onEnd = (socket) => () => {
     }
 
     removeUser(socket);
+    removeClient(socket);
   } catch (err) {
     console.error('onEnd error: ', err);
   }

--- a/src/handlers/game/monsterDeath.handler.js
+++ b/src/handlers/game/monsterDeath.handler.js
@@ -1,4 +1,3 @@
-import { getGameSessionById } from '../../sessions/game.session.js';
 import { getUserBySocket } from '../../sessions/user.session.js';
 
 export const monsterDeathNotifyHandler = async ({ packetType, data, socket }) => {
@@ -28,13 +27,12 @@ export const monsterDeathNotifyHandler = async ({ packetType, data, socket }) =>
     user.score += 100;
     user.gold += 100;
 
-    // 이제 다른 유저에게 나의 몬스터상황 알려주기 // 이게 맞기를
+    // 이제 다른 유저에게 나의 몬스터상황 알려주기
     gameSession.notifyEnemyMonsterDeath(user.id, monsterId);
 
     //user.getAllState();
     gameSession.getAllState(user.id);
   } catch (e) {
     console.error(e);
-    // handlerError(socket, e);
   }
 };

--- a/src/handlers/game/spawMonster.handler.js
+++ b/src/handlers/game/spawMonster.handler.js
@@ -16,8 +16,7 @@ export const spawnMonsterHandler = async ({ packetType, data, socket }) => {
     }
 
     // 세션 저장
-    const monster = new Monster(); // 유저에 몬스터 생성 및 정보 추가
-    user.addMonster(monster);
+    const monster = user.createMonster();
 
     const responseData = {
       monsterId: monster.id,

--- a/src/handlers/game/spawMonster.handler.js
+++ b/src/handlers/game/spawMonster.handler.js
@@ -1,6 +1,5 @@
 import Monster from '../../classes/models/monster.class.js';
 import { PacketType } from '../../constants/header.js';
-import { getGameSessionById } from '../../sessions/game.session.js';
 import { getUserBySocket } from '../../sessions/user.session.js';
 import { createResponse } from '../../utils/response/createRespose.js';
 
@@ -25,7 +24,11 @@ export const spawnMonsterHandler = async ({ packetType, data, socket }) => {
       monsterNumber: monster.monsterNumber,
     };
 
-    const spawnMonsterResponse = createResponse(PacketType.SPAWN_MONSTER_RESPONSE, responseData);
+    const spawnMonsterResponse = createResponse(
+      PacketType.SPAWN_MONSTER_RESPONSE,
+      responseData,
+      socket,
+    );
 
     socket.write(spawnMonsterResponse);
 

--- a/src/handlers/tower/towerAttack.handler.js
+++ b/src/handlers/tower/towerAttack.handler.js
@@ -5,7 +5,7 @@ import { createEnemyTowerAttackNotification } from '../../utils/notification/tow
 export const towerAttackHandler = async ({ packetType, data, socket }) => {
   try {
     const { towerId, monsterId } = data;
-    console.log('towerId , monsterId', towerId, monsterId);
+    console.log('towerId , monsterId', towerId, monsterId); // 왜 가끔 0번을 주지?
 
     const currentUser = getUserBySocket(socket);
 
@@ -14,7 +14,7 @@ export const towerAttackHandler = async ({ packetType, data, socket }) => {
       // 타워가 없음
       console.log(currentUser.towers);
       console.log(tower);
-      console.error('타워를 찾을 수 없습니다.'); // 이게 뜨면 생각한게 맞는건데
+      console.error('타워를 찾을 수 없습니다.');
     }
 
     const monster = currentUser.getMonster(monsterId);

--- a/src/handlers/tower/towerPurchase.handler.js
+++ b/src/handlers/tower/towerPurchase.handler.js
@@ -30,7 +30,11 @@ export const towerPurchaseHandler = async ({ data, socket }) => {
       towerId: towerId,
     };
 
-    const towerPurchaseResponse = createResponse(PacketType.TOWER_PURCHASE_RESPONSE, responseData);
+    const towerPurchaseResponse = createResponse(
+      PacketType.TOWER_PURCHASE_RESPONSE,
+      responseData,
+      socket,
+    );
     socket.write(towerPurchaseResponse);
 
     const otherUsers = gameSession.users.filter((user) => user.id !== currentUser.id);

--- a/src/handlers/tower/towerPurchase.handler.js
+++ b/src/handlers/tower/towerPurchase.handler.js
@@ -14,14 +14,12 @@ export const towerPurchaseHandler = async ({ data, socket }) => {
       throw Error(); // 유저가 존재하지 않음
     }
 
-    const tower = new Tower(x, y);
+    const tower = currentUser.createTower(x, y); // 타워 추가
     const towerId = tower.id;
 
     currentUser.gold -= 3000;
 
     console.log('타워 구매됨 tower: ', tower);
-
-    currentUser.addTower(tower); // 타워 추가
 
     // 돈 검증
     const gameSession = getGameSessionById(currentUser.getGameSession().id);

--- a/src/handlers/user/login.handler.js
+++ b/src/handlers/user/login.handler.js
@@ -85,7 +85,7 @@ export const loginHandler = async ({ packetType, data, socket }) => {
       }
     }
 
-    const loginResponse = createResponse(PacketType.LOGIN_RESPONSE, responseData);
+    const loginResponse = createResponse(PacketType.LOGIN_RESPONSE, responseData, socket);
     socket.write(loginResponse);
   } catch (e) {
     console.error('Login handler error: ', e);

--- a/src/handlers/user/register.handler.js
+++ b/src/handlers/user/register.handler.js
@@ -50,7 +50,7 @@ export const registerHandler = async ({ packetType, data, socket }) => {
       };
     }
 
-    const registerResponse = createResponse(PacketType.REGISTER_RESPONSE, responseData);
+    const registerResponse = createResponse(PacketType.REGISTER_RESPONSE, responseData, socket);
 
     socket.write(registerResponse);
     console.log('register complete');
@@ -62,6 +62,6 @@ export const registerHandler = async ({ packetType, data, socket }) => {
       message: '회원가입 처리 중 예상치 못한 오류가 발생했습니다.',
       failCode: config.globalFailCode.UNKNOWN_ERROR,
     };
-    socket.write(createResponse(PacketType.REGISTER_RESPONSE, errorResponse));
+    socket.write(createResponse(PacketType.REGISTER_RESPONSE, errorResponse, socket));
   }
 };

--- a/src/sessions/client.session.js
+++ b/src/sessions/client.session.js
@@ -1,0 +1,23 @@
+import Client from '../classes/models/client.class.js';
+import { clientSessions } from './sessions.js';
+
+export const addClient = (socket) => {
+  const client = new Client(socket);
+  clientSessions.push(client);
+  return client;
+};
+
+export const removeClient = (socket) => {
+  const index = clientSessions.findIndex((client) => client.socket === socket);
+  if (index !== -1) {
+    return clientSessions.splice(index, 1)[0];
+  }
+};
+
+export const getAllClient = () => {
+  return clientSessions;
+};
+
+export const getClientBySocket = (socket) => {
+  return clientSessions.find((client) => client.socket === socket);
+};

--- a/src/sessions/sessions.js
+++ b/src/sessions/sessions.js
@@ -1,3 +1,5 @@
 export const gameSessions = [];
 
 export const userSessions = [];
+
+export const clientSessions = [];

--- a/src/utils/notification/game.notification.js
+++ b/src/utils/notification/game.notification.js
@@ -24,7 +24,14 @@ export const makeNotification = (packetType, data, socket) => {
     const gamePacketInstance = gamePacket.create({ [gamePacketFieldName]: notificationInstance });
 
     const client = getClientBySocket(socket);
-    const sequence = client.getSequence();
+    let sequence;
+    // 아 이게 강제로 나갔을때 에러가 나네
+    if (client) {
+      sequence = client.getSequence();
+    } else {
+      sequence = 0;
+    }
+
     const buffer = gamePacket.encode(gamePacketInstance).finish();
 
     const headerPacket = createHeader(packetType, sequence, buffer.length);

--- a/src/utils/notification/game.notification.js
+++ b/src/utils/notification/game.notification.js
@@ -1,5 +1,6 @@
 import { PacketType } from '../../constants/header.js';
 import { getProtoMessages } from '../../init/loadProto.js';
+import { getClientBySocket } from '../../sessions/client.session.js';
 import { createHeader } from '../response/createHeader.js';
 import { notificationProto } from './notificationPoroto.js';
 
@@ -8,7 +9,7 @@ import { notificationProto } from './notificationPoroto.js';
  * @param {*} data 페이로드
  * @returns
  */
-export const makeNotification = (packetType, data) => {
+export const makeNotification = (packetType, data, socket) => {
   try {
     const protoMessages = getProtoMessages();
     const gamePacket = protoMessages['protoPacket']['GamePacket'];
@@ -22,7 +23,8 @@ export const makeNotification = (packetType, data) => {
     const gamePacketFieldName = notificationProto[packetType].fieldName;
     const gamePacketInstance = gamePacket.create({ [gamePacketFieldName]: notificationInstance });
 
-    const sequence = 0;
+    const client = getClientBySocket(socket);
+    const sequence = client.getSequence();
     const buffer = gamePacket.encode(gamePacketInstance).finish();
 
     const headerPacket = createHeader(packetType, sequence, buffer.length);
@@ -33,7 +35,7 @@ export const makeNotification = (packetType, data) => {
   }
 };
 
-export const createMatchStartNotification = (user, opponent) => {
+export const createMatchStartNotification = (user, opponent, socket) => {
   const initialGameStateData = user.gameSession.initialGameState;
 
   const playerGameData = {
@@ -68,5 +70,5 @@ export const createMatchStartNotification = (user, opponent) => {
 
   const protoType = PacketType.MATCH_START_NOTIFICATION;
 
-  return makeNotification(protoType, notifiData);
+  return makeNotification(protoType, notifiData, socket);
 };

--- a/src/utils/notification/tower.notification.js
+++ b/src/utils/notification/tower.notification.js
@@ -12,8 +12,8 @@ export const createAddEnemyTowerNotification = (data, otherUser) => {
 
   const protoType = PacketType.ADD_ENEMY_TOWER_NOTIFICATION;
 
-  const packet = makeNotification(protoType, notifiData);
   otherUser.forEach((user) => {
+    const packet = makeNotification(protoType, notifiData, user.socket);
     user.socket.write(packet);
   });
 };
@@ -28,10 +28,9 @@ export const createEnemyTowerAttackNotification = (data, otherUser) => {
 
   const protoType = PacketType.ENEMY_TOWER_ATTACK_NOTIFICATION;
 
-  const packet = makeNotification(protoType, notifiData);
-
   // 같은 세션에 있는 다른 유저에게 현재 클라이언트가 공격한 타워정보, 몬스터 정보를 주었습니다. 그래야 다른 클라이언트에서 해당 타워를 공격하게 해줄텐데
   otherUser.forEach((user) => {
+    const packet = makeNotification(protoType, notifiData, user.socket);
     user.socket.write(packet);
   });
 };

--- a/src/utils/response/createRespose.js
+++ b/src/utils/response/createRespose.js
@@ -28,7 +28,13 @@ export const createResponse = (packetType, responseData, socket) => {
     const gamePacketInstance = gamePacket.create({ [gamePacketFieldName]: responseInstance });
 
     const client = getClientBySocket(socket);
-    const sequence = client.getSequence();
+    let sequence;
+    // 아 이게 강제로 나갔을때 에러가 나네
+    if (client) {
+      sequence = client.getSequence();
+    } else {
+      sequence = 0;
+    }
     const buffer = gamePacket.encode(gamePacketInstance).finish();
 
     const headerPacket = createHeader(packetType, sequence, buffer.length);

--- a/src/utils/response/createRespose.js
+++ b/src/utils/response/createRespose.js
@@ -1,38 +1,40 @@
 import { getProtoMessages } from '../../init/loadProto.js';
+import { getClientBySocket } from '../../sessions/client.session.js';
 import { createHeader } from './createHeader.js';
 import { responseProto } from './responseProto.js';
 
 /**
- * @param {*} packetType 응답 패킷 타입 
+ * @param {*} packetType 응답 패킷 타입
  * @param {*} responseData 응답 데이터
  * @returns
  */
-export const createResponse = (packetType, responseData) => {
-    try {
-        const protoMessages = getProtoMessages();
-        const gamePacket = protoMessages['protoPacket']['GamePacket'];
+export const createResponse = (packetType, responseData, socket) => {
+  try {
+    const protoMessages = getProtoMessages();
+    const gamePacket = protoMessages['protoPacket']['GamePacket'];
 
-        // 따로 저장한 responseProto에서 protoType을 가져옴
-        const [namespace, typeName] = responseProto[packetType].protoType.split('.');
-        const response = protoMessages[namespace][typeName];
+    // 따로 저장한 responseProto에서 protoType을 가져옴
+    const [namespace, typeName] = responseProto[packetType].protoType.split('.');
+    const response = protoMessages[namespace][typeName];
 
-        const responseInstance = response.create(responseData);
+    const responseInstance = response.create(responseData);
 
-        // GamePacket의 필드 이름을 찾아 오는 부분인데... 성능이 떨어짐
-        // const responsePayload = Object.keys(gamePacket.fields).find(
-        //   (type) => gamePacket.fields[type].type === typeName,
-        // );
+    // GamePacket의 필드 이름을 찾아 오는 부분인데... 성능이 떨어짐
+    // const responsePayload = Object.keys(gamePacket.fields).find(
+    //   (type) => gamePacket.fields[type].type === typeName,
+    // );
 
-        const gamePacketFieldName = responseProto[packetType].fieldName;
-        const gamePacketInstance = gamePacket.create({ [gamePacketFieldName]: responseInstance });
+    const gamePacketFieldName = responseProto[packetType].fieldName;
+    const gamePacketInstance = gamePacket.create({ [gamePacketFieldName]: responseInstance });
 
-        const sequence = 0;
-        const buffer = gamePacket.encode(gamePacketInstance).finish();
+    const client = getClientBySocket(socket);
+    const sequence = client.getSequence();
+    const buffer = gamePacket.encode(gamePacketInstance).finish();
 
-        const headerPacket = createHeader(packetType, sequence, buffer.length);
+    const headerPacket = createHeader(packetType, sequence, buffer.length);
 
-        return Buffer.concat([headerPacket, buffer]);
-    } catch (e) {
-        console.error(e);
-    }
+    return Buffer.concat([headerPacket, buffer]);
+  } catch (e) {
+    console.error(e);
+  }
 };


### PR DESCRIPTION
- 연결된 클라이언트 정보를 만들 Client클래스를 만들어 Client세션을 따로 저장하였습니다.
(onConnection.js에 Client정보 세션에 저장 및 onEnd.js에 연결종료시 세션에 삭제 로직 추가)

- client.session.js를 통해 생성한 Client인스터스에 sequence값들을 관리하게 해주었습니다.

- onData.js에서 해당 클라이언트의 시퀀스값을 업데이트 해주었고 시퀀스 값도 검사해주었습니다.

- 해당 createResponse, makeNotification함수에 socket매개변수 추가하여 해당 클라이언트의 sequence값을 찾아 주게 로직 변경하였습니다. (위에 두개 함수 실행하는 부분에서도 로직 수정해보았습니다. 확인해주시면 감사하겠습니다.)

- 몬스터 및 타워 설치시 바로 유저정보에 들어 갈 수 있도록 로직 수정하였습니다.

- 고민 중 시퀀스 업데이트(증가)를 response보낼때 올려 주는 것이 맞을지 고민입니다.

- 현재 타워 및 몬스터를 못찾는 에러가 중간중간 발생합니다. (이 문제 해결시 createResponse만들때 시퀀스 값을 올려주어도 될 것 같습니다.)

- 몬스터 못찾는 에러 이유: 현재 클라이언트에서 죽은 몬스터(오브젝트)가 실제로 사라지기전에 공격을 하여 공격을 했다는 요청을 서버에 보냅니다. 하지만 서버에선 해당 몬스터를 이미 세션에서 죽음처리하여 없애주어서 찾을 수 없는 에러가 있습니다. (어떻게 처리할지 고민 중...)
- 
- 타워를 못찾는 에러의 이유 : 찾는 중 입니다...